### PR TITLE
Fix undefined `version` variable in complete_pom.rb

### DIFF
--- a/complete_pom.rb
+++ b/complete_pom.rb
@@ -138,7 +138,8 @@ dir = File.join(*[
 ])
 
 Dir.chdir(dir) do
-  if ARGV[2].nil?
+  version = ARGV[2]
+  if version.nil?
     pom_file_paths = Dir.glob("**/*.pom").sort
   else
     pom_file_paths = [


### PR DESCRIPTION
Fixed the error when passing `version` parameters to `complete_pom.rb`.

```
./complete_pom.rb:147:in `block in <main>': undefined local variable or method `version' for main:Object (NameError)
```
